### PR TITLE
fix(bookmark.ts): fix the bookmark container issue on baidu result pages

### DIFF
--- a/src/content/bookmark.ts
+++ b/src/content/bookmark.ts
@@ -14,8 +14,20 @@ class BookmarkSearch {
         if (this.host.endsWith('.baidu.com')) {
             this.getKeyword = () => ($('#kw')[0]['value'] as string)
             this.innerClass = '#content_left'
+            let interval = null
             $('#kw').bind('input propertychange', () => {
-                this.sendSearch(this.getKeyword())
+                // Have to wait for the container to appear
+                if (interval !== null) {
+                    clearInterval(interval)
+                    interval = null
+                }
+                interval = setInterval(() => {
+                    if ($(this.innerClass).length > 0) {
+                        clearInterval(interval)
+                        interval = null
+                        this.sendSearch(this.getKeyword())
+                    }
+                }, 100)
             })
         } else if (this.host.startsWith('www.google.')) {
             this.getKeyword = () => ($('input.gsfi')[0]['value'] as string)


### PR DESCRIPTION
Baidu search page is now a single page application, in which the result container is created only after first search. Bookmark search result has to wait for the container to place itself in.