### PR TITLE
fix(switchInfo): fix inconsistent states of switchInfo

### DIFF
--- a/src/guide/common/switchInfo/index.ts
+++ b/src/guide/common/switchInfo/index.ts
@@ -47,11 +47,10 @@ export class SwitchInfo {
             </div>
         `;
         this.divElement.querySelector('.right').addEventListener('click', async (ev: MouseEvent) => {
+            this.options.on = !this.options.on
             const newConfig = await getCoreConfig()
-            newConfig[this.options.key] = !this.options.on
-            setCoreConfig(newConfig)
-            message.send('refresh-config')
-            window.dispatchEvent(new Event("refresh"))
+            newConfig[this.options.key] = this.options.on
+            setCoreConfig(newConfig).then(() => { message.send('refresh-config') })
         })
     }
 }

--- a/src/option/common/switchInfo/index.ts
+++ b/src/option/common/switchInfo/index.ts
@@ -47,8 +47,9 @@ export class SwitchInfo {
             </div>
         `;
         this.divElement.querySelector('.right input').addEventListener('click', async (ev: MouseEvent) => {
+            this.options.on = !this.options.on
             const newConfig = await getCoreConfig()
-            newConfig[this.options.key] = !this.options.on
+            newConfig[this.options.key] = this.options.on
             setCoreConfig(newConfig).then(() => message.send('refresh-config'))
         })
     }


### PR DESCRIPTION
A logical bug: When switches on option/guide pages are clicked multiple times rapidly, states of the UI and the configuration could be inconsistent.
This PR should fix it.